### PR TITLE
fix: nodes display should corrspond to the initial visualization

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -70,14 +70,18 @@ function getVisualizationFromLocalStorage(): PopulatedVisualization {
     const nonFilteredNodes = parentWindowOgma.getNonFilteredNodes();
     const nonFilteredEdges = parentWindowOgma.getNonFilteredEdges();
 
+    // getAttributes call is expensive, do the call only once for nodes and edges
+    const nonFilteredNodesAttributes = nonFilteredNodes.getAttributes();
+    const nonFilteredEdgesAttributes = nonFilteredEdges.getAttributes();
+
     const nodes = nonFilteredNodes.toJSON().map((n, index) => ({
       ...n,
-      attributes: nonFilteredNodes.getAttributes()[index]
+      attributes: nonFilteredNodesAttributes[index]
     })) as VizNode[];
 
     const edges = nonFilteredEdges.toJSON().map((e, index) => ({
       ...e,
-      attributes: nonFilteredEdges.getAttributes()[index]
+      attributes: nonFilteredEdgesAttributes[index]
     })) as VizEdge[];
 
     const visualization = JSON.parse(storeVisualizationData!) as Visualization;

--- a/src/api.ts
+++ b/src/api.ts
@@ -81,11 +81,13 @@ function getVisualizationFromLocalStorage(): PopulatedVisualization {
     })) as VizEdge[];
 
     const visualization = JSON.parse(storeVisualizationData!) as Visualization;
-    return {
+
+    // We need to clone the object because attributes get mutated by the parent ogma
+    return structuredClone({
       ...visualization,
       nodes,
       edges
-    };
+    });
   }
   return {} as PopulatedVisualization;
 }


### PR DESCRIPTION
## What
Fix a note position bug introduced by https://github.com/Linkurious/lke-plugin-image-export/pull/178 

## Why
Before: see the video

https://github.com/user-attachments/assets/5f145b40-bd2b-43d6-9174-dea04a7a8d07


After: the display is correct

https://github.com/user-attachments/assets/89cc704a-5c08-4242-9172-9e833852be01

## How
This was because the nodes position attributes were mutated by the parent ogma after the popup is displayed. So we clone the object to get a snapshot of them.

